### PR TITLE
Initial `no_std` (and no alloc) support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,8 +17,107 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
-      - name: test
+      - name: test-all-features
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all-features
+      - name: test-default-features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+      - name: test-no-features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features
+      - name: test-feature-alloc
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=alloc
+      - name: test-feature-postgres-types
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=postgres-types
+      - name: test-feature-node_pubkey_verify
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=node_pubkey_verify
+      - name: test-feature-node_pubkey_recovery
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=node_pubkey_recovery
+      - name: test-feature-bitcoin_std
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=bitcoin_std
+      - name: test-feature-bitcoin_no_std
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=bitcoin_no_std
+      - name: test-feature-serde
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=serde
+      - name: test-feature-serde-std
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=serde_std
+      - name: test-feature-serde-alloc
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=serde_alloc
+      - name: test-feature-parse_arg
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=parse_arg
+      - name: test-feature-secp256k1
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=secp256k1
+      - name: test-feature-secp256k1-std
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=secp256k1_std
+      - name: test-feature-slog
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=slog
+      - name: test-feature-slog-std
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=slog_std
+      - name: test-compat-slog-std
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=slog,std
+      - name: test-compat-serde-std
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=serde,std
+      - name: test-compat-serde-alloc
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=serde,alloc
+      - name: test-compat-secp256k1-std
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=secp256k1,std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,18 +15,27 @@ features = ["serde", "node_pubkey_verify", "node_pubkey_recovery", "bitcoin/use-
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-postgres-types = ["postgres-types-real", "bytes"]
+default = ["std"]
+std = ["alloc"]
+alloc = []
+postgres-types = ["postgres-types-real", "bytes", "std"]
 node_pubkey_verify = ["secp256k1/bitcoin_hashes"]
 node_pubkey_recovery = ["node_pubkey_verify", "secp256k1/recovery"]
+bitcoin_std = ["bitcoin/std", "std"]
+bitcoin_no_std = ["bitcoin/no-std", "alloc"]
+secp256k1_std = ["secp256k1/std", "std"]
+serde_alloc = ["alloc", "serde/alloc"]
+serde_std = ["std", "serde_alloc", "serde/std"]
+slog_std = ["std", "slog/std"]
 
 [dependencies]
-serde = { version = "1.0.130", optional = true }
+serde = { version = "1.0.130", optional = true, default-features = false }
 # Warning: don't depend on this as a feature!
 postgres-types-real = { package = "postgres-types", version = "0.2.2", optional = true }
 parse_arg = { version = "0.1.4", optional = true }
-bitcoin = { version = "0.27.1", optional = true }
-secp256k1 = { version = "0.20.3", optional = true }
-slog = { version = "2.7.0", optional = true }
+bitcoin = { version = "0.27.1", optional = true, default-features = false }
+secp256k1 = { version = "0.20.3", optional = true, default-features = false, features = ["alloc"] }
+slog = { version = "2.7.0", optional = true, default-features = false }
 
 # Warning: don't depend on this as a feature!
 bytes = { version = "1.1.0", optional = true }

--- a/src/err_fmt.rs
+++ b/src/err_fmt.rs
@@ -1,0 +1,126 @@
+/// Macros helping with implementations of error formatting.
+
+use core::fmt;
+
+/// Zero-sized version of empty string
+pub(crate) struct Empty;
+
+impl fmt::Display for Empty {
+    fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+        Ok(())
+    }
+}
+
+/// Displays error with sources delimited by `: `
+#[cfg(all(not(feature = "slog_std"), feature = "std"))]
+pub(crate) struct JoinErrSources<'a, T: std::error::Error + 'static>(pub &'a T);
+
+#[cfg(all(not(feature = "slog_std"), feature = "std"))]
+impl<'a, T: std::error::Error + 'static> fmt::Display for JoinErrSources<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)?;
+        let mut error = self.0 as &(dyn std::error::Error + 'static);
+        while let Some(source) = error.source() {
+            write!(f, ": {}", self.0)?;
+            error = source;
+        }
+        Ok(())
+    }
+}
+
+/// Displays `$value` conditioned on `$feature`
+///
+/// `$value` may be an invalid expression (e.g. missing struct field) if the `$feature` is *off*.
+/// Using `not("feature)"` negates the effect.
+macro_rules! opt_fmt {
+    (not($feature:literal), $value:expr) => {
+        {
+            #[cfg(not(feature = $feature))]
+            {
+                $value
+            }
+            #[cfg(feature = $feature)]
+            {
+                $crate::err_fmt::Empty
+            }
+        }
+    };
+    ($feature:literal, $value:expr) => {
+        {
+            #[cfg(feature = $feature)]
+            {
+                $value
+            }
+            #[cfg(not(feature = $feature))]
+            {
+                $crate::err_fmt::Empty
+            }
+        }
+    };
+}
+
+/// Formats error optionally with error source appended (delimited by `: `) *if `$feature` is OFF*
+macro_rules! write_err_ext {
+    ($feature:literal, $writer:expr, $string:literal $(, $args:expr),*; $source:expr) => {
+        {
+            let _ = &$source;
+            write!($writer, concat!($string, "{}") $(, $args)*, opt_fmt!(not($feature), format_args!(": {}", $source)))
+        }
+    }
+}
+
+/// Formats error optionally with error source appended (delimited by `: `) *if `std` feature is OFF*
+macro_rules! write_err {
+    ($writer:expr, $string:literal $(, $args:expr)*; $source:expr) => {
+        write_err_ext!("std", $writer, $string $(, $args)*; $source)
+    }
+}
+
+/// Implements feature-agnostic test(s) of error formatting.
+///
+/// This implements test that works correctly with `alloc`, `std` or without any of them.
+/// Thus all combinations can be checked by using this macro once.
+/// Obviously, the test must be run multiple times, each with a different set of features.
+#[cfg(test)]
+macro_rules! chk_err_impl {
+    ($($test_name:ident, $input:expr, $type:ty, $sources_alloc:expr, $sources_no_alloc:expr);* $(;)?) => {
+        $(
+        #[test]
+        fn $test_name() {
+            use alloc::string::ToString;
+            let error = $input.parse::<$type>().unwrap_err();
+
+            #[cfg(feature = "alloc")]
+            let sources = $sources_alloc;
+            #[cfg(feature = "alloc")]
+            let _ = $sources_no_alloc;
+            #[cfg(not(feature = "alloc"))]
+            let sources = $sources_no_alloc;
+            #[cfg(not(feature = "alloc"))]
+            let _ = $sources_alloc;
+
+            #[cfg(feature = "std")]
+            {
+                let mut sources = sources.iter();
+                let mut source = Some(&error as &(dyn std::error::Error + 'static));
+                loop {
+                    match (source, sources.next()) {
+                        (Some(produced), Some(expected)) => {
+                            assert_eq!(produced.to_string(), *expected);
+                            source = produced.source();
+                        },
+                        (None, None) => break,
+                        (Some(_), None) => panic!("more sources than expected"),
+                        (None, Some(_)) => panic!("less sources than expected"),
+                    }
+                }
+            }
+            #[cfg(not(feature = "std"))]
+            {
+                let expected = sources.join(": ");
+                assert_eq!(error.to_string(), expected);
+            }
+        }
+        )*
+    }
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2,11 +2,25 @@
 macro_rules! impl_error_value {
     ($($type:ty),+) => {
         $(
-            /// Implemented using `emit_error`
+            /// Implemented using `emit_error` if `slog_std` feature is enabled, calls
+            /// `emit_arguments` with sources separated by `: ` otherwise.
             #[cfg_attr(docsrs, doc(cfg(feature = "slog")))]
             impl Value for $type {
                 fn serialize(&self, _rec: &Record, key: Key, serializer: &mut dyn Serializer) -> slog::Result {
-                    serializer.emit_error(key, self)
+                    {
+                        #[cfg(feature = "slog_std")]
+                        {
+                            serializer.emit_error(key, self)
+                        }
+                        #[cfg(all(not(feature = "slog_std"), feature = "std"))]
+                        {
+                            serializer.emit_arguments(key, &format_args!("{}", $crate::err_fmt::JoinErrSources(self)))
+                        }
+                        #[cfg(not(feature = "std"))]
+                        {
+                            serializer.emit_arguments(key, &format_args!("{}", self))
+                        }
+                    }
                 }
             }
         )+


### PR DESCRIPTION
This removes the requirement to use `std` and `alloc` and provides them
as features. However this is mainly intended as a way to add those
features in a single breaking release and avoid breaking later.

The support still has a few issues:
* `P2PAddress` is not enabled without `std`, this is related to IP
   addresses being in `std`.
   See also https://github.com/rust-lang/rfcs/pull/2832
* ~~This introduces incompatibility hazard: one crate could turn on `std`
  while another turns on `serde` - the error types will fail to compile.
  This could be fixed by the upcoming weak dependency features but MSRV
  issues. :(~~ Fixed in followup commit
  Thankfully the incompatibility is trivial to fix but not sure if it's
  still a good idea. At least we have a warning about it.
* `bitcoin` integration is annoying because of that crates poor `no_std`
  implementation.

I'm making this a PR and will keep it open for a bit in case people have ideas how to do this better.

Closes #6 