### PR TITLE
Removed unused features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,21 +56,11 @@ jobs:
         with:
           command: test
           args: --no-default-features --features=bitcoin_std
-      - name: test-feature-bitcoin_no_std
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features --features=bitcoin_no_std
       - name: test-feature-serde
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --no-default-features --features=serde
-      - name: test-feature-serde-std
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features --features=serde_std
       - name: test-feature-serde-alloc
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,11 @@ alloc = []
 postgres-types = ["postgres-types-real", "bytes", "std"]
 node_pubkey_verify = ["secp256k1/bitcoin_hashes"]
 node_pubkey_recovery = ["node_pubkey_verify", "secp256k1/recovery"]
-bitcoin_std = ["bitcoin/std", "std"]
-bitcoin_no_std = ["bitcoin/no-std", "alloc"]
 secp256k1_std = ["secp256k1/std", "std"]
 serde_alloc = ["alloc", "serde/alloc"]
-serde_std = ["std", "serde_alloc", "serde/std"]
 slog_std = ["std", "slog/std"]
+# Used for testing only - do NOT depend on this!
+bitcoin_std = ["bitcoin/std", "std"]
 
 [dependencies]
 serde = { version = "1.0.130", optional = true, default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,7 @@
 //!           Enabled by default, implies `alloc.
 //! * `alloc` - enables conversions from/to heap-allocated types as well as additional error
 //!             information.
-//! * [`bitcoin`] - converting between types, you should use `bitcoin_std` feature if you need
-//!                 `std`.
+//! * [`bitcoin`] - converting between types
 //! * [`serde`] - serialization and deserialization of types
 //! * [`postgres-types`](postgres_types) - storing and retrieving from SQL
 //! * [`parse_arg`] - parsing arguments into types in this crate
@@ -51,14 +50,10 @@
 //! * `node_pubkey_recovery` - convenience function for verifying lightning messages
 //!                            signed with [`NodePubkey`], implies `node_pubkey_verify` and
 //!                            `secp256k1/recovery`
-//! * `bitcoin_std` - enables `std` feature in `bitcoin`, currently just for convenience
-//! * `bitcoin_no_std` - enables `no_std` feature in `bitcoin`, currently just for convenience
 //! * `secp256k1_std` - required for [`node_pubkey::ParseError`] to return `secp256k1::Error` from
 //!                     `source()` method of [`std::error::Error`]
 //! * `serde_alloc` - required for specialization of `serde::de::Visitor::visit_string` method to
 //!                   avoid allocation
-//! * `serde_std` - currently just implies `serde_alloc` and `std`, may be important for error
-//!                 handling in the future
 //! * `slog_std` - required for error types to use [`slog::Serializer::emit_error`] for logging
 //!
 //! Feel free to contribute your own!


### PR DESCRIPTION
After better analysis it was determined that these features don't help
with forward compatibility and only slightly improve convenience. The
noise is probably not worth it.

`bitcoin_*` were somewhat more interesting because the `bitcoin` crate
has sad `no_std` support but there's hope it'll be improved and even if
not adding features is better than removing. (The features weren't
released yet.)

Closes #10